### PR TITLE
Add travis yml file to configure google app engine automatic deployments from master branch to assigned project in cloud console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+sudo: required
+before_install:
+- echo $GCLOUD_CREDENTIALS | openssl enc -d -aes-256-cbc -base64 -A -k $GCLOUD_CREDENTIALS_KEY > fhir-org-cds-services.json
+branches:
+  only:
+    - master
+node_js:
+  - '8.9.1'
+cache:
+  directories:
+    - node_modules
+deploy:
+  provider: gae
+  skip_cleanup: true
+  keyfile: fhir-org-cds-services.json
+  project: fhir-org-cds-services
+  default: true
+  no_promote: true
+  no_stop_previous_version: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "sandbox-cds-services",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sandbox-cds-services",
+  "version": "1.0.0",
+  "description": "Default CDS Services for the CDS Hooks Sandbox",
+  "license": "Apache-2.0",
+  "main": "server.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cds-hooks/sandbox-cds-services.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cds-hooks/sandbox-cds-services/issues"
+  },
+  "homepage": "https://github.com/cds-hooks/sandbox-cds-services#readme"
+}


### PR DESCRIPTION
Currently, to deploy any code to a google app engine project, it is done via a command `gcloud app deploy`. This happens manually and the entity executing this deployment to the google project must have permissions set in the cloud console to deploy to a specific project. 

We should create a pipeline to allow Github to automatically deploy to our google app engine project upon any merge/commit to master. We can configure this automatic deployment via [Travis-CI](https://docs.travis-ci.com/user/deployment/google-app-engine/). There is a service account created for the `sandbox-cds-services` cloud project which has an encrypted key (included in this PR) that can be decrypted via a travis deploy trigger. This allows Travis to automatically deploy the `master` build to the cloud project. The permissions set for this service account is of the role, `App Engine Deployer`.

This allows others to contribute to these sandbox cds services without having to ask for permissions from the google cloud project to deploy, if their change is merged into the `master` branch. 