### PR TITLE
Check passed in FHIR server if possible for any needed resources if prefetch expectations are not met

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 tests/**
+coverage/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
 node_js:
-  - '8.9.1'
+  - 'lts/*'
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sandbox CDS Services
+# Sandbox CDS Services [![Coverage Status](https://coveralls.io/repos/github/cds-hooks/sandbox-cds-services/badge.svg?branch=master)](https://coveralls.io/github/cds-hooks/sandbox-cds-services?branch=master)
 This repository hosts the default CDS Services configured for the [CDS Hooks Sandbox](http://sandbox.cds-hooks.org) tool. These services are spun up by a Node.js application hosted on Google App Engine.
 
 ## Getting Started
@@ -9,7 +9,7 @@ npm install
 
 Once the dependencies are installed locally, you can run the server on localhost.
 ```javascript
-npm start
+npm run dev
 ```
 
 You can test out this app from `http://localhost:3000`. Try hitting the discovery endpoint at `http://localhost:3000/cds-services`.
@@ -21,7 +21,7 @@ To lint:
 ```javascript
 npm run lint
 ```
-This project contains unit tests using the [Jest](https://facebook.github.io/jest/) library. Discovery and CDS Service endpoints are tested by each route and expected behavior. 
+This project contains unit tests using the [Jest](https://facebook.github.io/jest/) library. Discovery and CDS Service endpoints are tested by each route and expected behavior.
 
 To test:
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,45 +1,16 @@
-/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
-
 const express = require('express');
 const bodyParser = require('body-parser');
 const cdsServices = require('./discovery/cds-services');
+const defaultCors = require('./middleware/default-cors');
+const errorHandler = require('./middleware/error-handler');
 
 const app = express();
-
-const isValidJson = (obj) => {
-  try {
-    JSON.stringify(obj);
-    return true;
-  } catch (err) {
-    return false;
-  }
-};
 
 // This is necessary middleware to parse JSON into the incoming request body for POST requests
 app.use(bodyParser.json());
 
 // CDS Services must implement CORS to be called from a web browser
-app.use((request, response, next) => {
-  response.set({
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Credentials': 'true',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    'Access-Control-Expose-Headers': 'Origin, Accept, Content-Location, Location, X-Requested-With',
-    'Content-Type': 'application/json; charset=utf-8',
-  });
-  next();
-});
-
-app.use((request, response, next) => {
-  if (request.body) {
-    if (!isValidJson(request.body)) {
-      response.sendStatus(400);
-      return;
-    }
-  }
-  next();
-});
+app.use(defaultCors);
 
 app.set('json spaces', '  ');
 
@@ -52,11 +23,6 @@ app.use((request, response, next) => {
 });
 
 // Handle specified errors or return a 500 for internal errors
-app.use((err, request, response, next) => {
-  const status = err.status || 500;
-  response.status(status);
-  response.set('Content-Type', 'text/html');
-  response.send(status !== 500 ? err.message : 'Internal Server Error');
-});
+app.use(errorHandler);
 
 module.exports = app;

--- a/middleware/default-cors.js
+++ b/middleware/default-cors.js
@@ -1,0 +1,11 @@
+module.exports = (request, response, next) => {
+  response.set({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Expose-Headers': 'Origin, Accept, Content-Location, Location, X-Requested-With',
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  next();
+};

--- a/middleware/error-handler.js
+++ b/middleware/error-handler.js
@@ -1,0 +1,8 @@
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
+
+module.exports = (err, request, response, next) => {
+  const status = err.status || 500;
+  response.status(status);
+  response.set('Content-Type', 'text/html');
+  response.send(status !== 500 ? err.message : 'Internal Server Error');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -93,6 +99,15 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "2.1.1"
+      }
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -224,8 +239,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -244,6 +258,24 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
+    },
+    "axios": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.0.tgz",
+      "integrity": "sha1-fadHkW24A/dhZR1gkdcIeJuVPGo=",
+      "requires": {
+        "follow-redirects": "1.2.5",
+        "is-buffer": "1.1.6"
+      }
+    },
+    "axios-mock-adapter": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.9.0.tgz",
+      "integrity": "sha1-Djh2Zvzq8/kSYhCaOVb1iLxq8tE=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -998,8 +1030,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "body-parser": {
       "version": "1.18.2",
@@ -1025,6 +1056,29 @@
       "dev": true,
       "requires": {
         "hoek": "4.2.0"
+      }
+    },
+    "boxen": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.3.0",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -1123,6 +1177,12 @@
       "integrity": "sha1-geO8ApcooDKTNQGZTvedscIRWeM=",
       "dev": true
     },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1176,7 +1236,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
@@ -1199,6 +1258,12 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
     "cli-cursor": {
@@ -1302,6 +1367,20 @@
         "typedarray": "0.0.6"
       }
     },
+    "configstore": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -1358,6 +1437,36 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "coveralls": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1388,6 +1497,12 @@
           }
         }
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -1425,6 +1540,18 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
     "deep-is": {
@@ -1509,6 +1636,27 @@
         "isarray": "1.0.0"
       }
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1552,6 +1700,12 @@
       "requires": {
         "is-arrayish": "0.2.1"
       }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1767,6 +1921,21 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
     },
     "exec-sh": {
       "version": "0.2.1",
@@ -2034,6 +2203,14 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2081,6 +2258,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -3059,6 +3242,15 @@
         "is-glob": "2.0.1"
       }
     },
+    "global-dirs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
+      }
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3077,6 +3269,25 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -3236,6 +3447,18 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3256,6 +3479,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
@@ -3310,7 +3539,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "binary-extensions": "1.10.0"
       }
@@ -3318,8 +3546,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3390,6 +3617,22 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.0",
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -3398,6 +3641,12 @@
       "requires": {
         "kind-of": "3.2.2"
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3441,6 +3690,12 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -3449,6 +3704,12 @@
       "requires": {
         "tryit": "1.0.3"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4047,6 +4308,15 @@
         "is-buffer": "1.1.6"
       }
     },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -4062,6 +4332,12 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -4115,10 +4391,111 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+      "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+      "dev": true,
+      "requires": {
+        "lodash.assign": "3.2.0",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "longest": {
@@ -4136,6 +4513,12 @@
         "js-tokens": "3.0.2"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -4146,6 +4529,23 @@
         "yallist": "2.1.2"
       }
     },
+    "make-dir": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -4154,6 +4554,12 @@
       "requires": {
         "tmpl": "1.0.4"
       }
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4299,6 +4705,33 @@
         "semver": "5.4.1",
         "shellwords": "0.1.1",
         "which": "1.3.0"
+      }
+    },
+    "nodemon": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.12.1.tgz",
+      "integrity": "sha1-mWpW3EnZ8Wu/G3ik3gjxNjSzh40=",
+      "dev": true,
+      "requires": {
+        "chokidar": "1.7.0",
+        "debug": "2.6.9",
+        "es6-promise": "3.3.1",
+        "ignore-by-default": "1.0.1",
+        "lodash.defaults": "3.1.2",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "touch": "3.1.0",
+        "undefsafe": "0.0.3",
+        "update-notifier": "2.3.0"
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -4484,6 +4917,18 @@
         "p-limit": "1.1.0"
       }
     },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -4563,6 +5008,15 @@
         "pify": "2.3.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4609,6 +5063,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
@@ -4676,6 +5136,15 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -4751,6 +5220,26 @@
         "unpipe": "1.0.0"
       }
     },
+    "rc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -4803,7 +5292,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
@@ -4852,6 +5340,25 @@
         "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.2",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -5065,6 +5572,15 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
@@ -5113,8 +5629,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.0.3",
@@ -5208,6 +5723,15 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5234,6 +5758,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
     },
     "string-length": {
       "version": "2.0.0",
@@ -5370,6 +5903,15 @@
         "string-width": "2.1.1"
       }
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0"
+      }
+    },
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
@@ -5457,6 +5999,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -5477,6 +6025,15 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "1.0.10"
+      }
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -5579,10 +6136,57 @@
       "dev": true,
       "optional": true
     },
+    "undefsafe": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
+      "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
+      "dev": true
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "dev": true,
+      "requires": {
+        "boxen": "1.2.2",
+        "chalk": "2.3.0",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -5717,6 +6321,46 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -5806,6 +6450,12 @@
         "imurmurhash": "0.1.4",
         "signal-exit": "3.0.2"
       }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "license": "Apache-2.0",
   "main": "server.js",
   "scripts": {
+    "dev": "nodemon server.js",
     "start": "node server.js",
     "lint": "./node_modules/.bin/eslint . --fix",
-    "test": "jest"
+    "test": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",
@@ -18,16 +19,26 @@
   },
   "homepage": "https://github.com/cds-hooks/sandbox-cds-services#readme",
   "dependencies": {
+    "axios": "^0.17.0",
     "body-parser": "^1.18.2",
     "express": "^4.16.2"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.9.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "coveralls": "^3.0.0",
     "eslint": "^4.10.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
     "jest": "^21.2.1",
+    "nodemon": "^1.12.1",
     "supertest": "^3.0.0"
+  },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "/node_modules",
+      "/tests/stubs"
+    ]
   }
 }

--- a/services/patient-greeting.js
+++ b/services/patient-greeting.js
@@ -1,26 +1,40 @@
 const express = require('express');
+const axios = require('axios');
 
 const router = express.Router();
 
-function isValidRequest(request) {
+function isDataAvailable(patient) {
+  return patient.name && patient.name[0] && patient.name[0].given && patient.name[0].given[0];
+}
+
+function isValidPrefetch(request) {
   const data = request.body;
   if (!(data && data.prefetch && data.prefetch.patient && data.prefetch.patient.resource)) {
     return false;
   }
-  const patient = data.prefetch.patient.resource;
-  return patient.name && patient.name[0] && patient.name[0].given && patient.name[0].given[0];
+  return isDataAvailable(data.prefetch.patient.resource);
 }
 
-// CDS Service endpoint
-router.post('/', (request, response) => {
-  if (!isValidRequest(request)) {
-    response.sendStatus(412);
-    return;
+function retrievePatientResource(fhirServer, patientId, accessToken) {
+  const headers = { Accept: 'application/json+fhir' };
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
   }
-  const data = request.body;
-  const patient = data.prefetch.patient.resource;
+  return axios({
+    method: 'get',
+    url: `${fhirServer}/Patient/${patientId}`,
+    headers,
+  }).then((result) => {
+    if (result.data && isDataAvailable(result.data)) {
+      return result.data;
+    }
+    throw new Error();
+  });
+}
+
+function buildCard(patient) {
   const name = patient.name[0].given[0];
-  const card = {
+  return {
     cards: [{
       summary: `Now seeing: ${name}`,
       source: {
@@ -29,7 +43,30 @@ router.post('/', (request, response) => {
       indicator: 'info',
     }],
   };
-  response.json(card);
+}
+
+// CDS Service endpoint
+router.post('/', (request, response) => {
+  if (!isValidPrefetch(request)) {
+    const { fhirServer, fhirAuthorization, patient } = request.body;
+    if (fhirServer && patient) {
+      let accessToken;
+      if (fhirAuthorization && fhirAuthorization.access_token) {
+        accessToken = fhirAuthorization.access_token;
+      }
+      retrievePatientResource(fhirServer, patient, accessToken)
+        .then((result) => {
+          response.json(buildCard(result));
+        }).catch(() => {
+          response.sendStatus(412);
+        });
+      return;
+    }
+    response.sendStatus(412);
+    return;
+  }
+  const { resource } = request.body.prefetch.patient;
+  response.json(buildCard(resource));
 });
 
 module.exports = router;

--- a/tests/middleware/error-handler.test.js
+++ b/tests/middleware/error-handler.test.js
@@ -1,0 +1,40 @@
+const errorHandler = require('../../middleware/error-handler');
+
+describe('Error Handler', () => {
+
+  let res;
+  beforeEach(() => {
+    res = {
+      data: null,
+      code: null,
+      status (status) {
+        this.code = status;
+        return this;
+      },
+      set: (data) => {
+        return null;
+      },
+      send (payload) {
+        this.data = payload;
+      }
+    };
+  });
+
+  test('returns a 404 if an error with that status has been passed in', () => {
+    const err = {
+      status: 404,
+      message: 'Not Found'
+    };
+    errorHandler(err, null, res, null);
+
+    expect(res.code).toBe(404);
+    expect(res.data).toBe('Not Found');
+  });
+
+  test('returns a 500 if no error status has been specified', () => {
+    errorHandler(new Error(), null, res, null);
+
+    expect(res.code).toBe(500);
+    expect(res.data).toBe('Internal Server Error');
+  });
+});

--- a/tests/patient-greeting.test.js
+++ b/tests/patient-greeting.test.js
@@ -1,15 +1,19 @@
 const request = require('supertest');
 const express = require('express');
+const axios = require('axios');
+const MockAdapter = require('axios-mock-adapter');
 
 const app = require('../index.js');
 const stub = require('./stubs/patient-greeting-stub');
 
 describe('Patient Greeting Service Endpoint', () => {
-  test('GET should respond with a 404 and empty body', (done) => {
-    request(app).get('/cds-services/patient-greeting').then((response) => {
-      expect(response.statusCode).toBe(404);
-      expect(response.body).toEqual({});
-      done();
+  describe('GET', () => {
+    test('should respond with a 404 and empty body', (done) => {
+      request(app).get('/cds-services/patient-greeting').then((response) => {
+        expect(response.statusCode).toBe(404);
+        expect(response.body).toEqual({});
+        done();
+      });
     });
   });
 
@@ -25,29 +29,130 @@ describe('Patient Greeting Service Endpoint', () => {
         });
     });
 
-    test('without prefetched data in a valid request should yield a 412 status and an empty body response', (done) => {
-      request(app)
-        .post('/cds-services/patient-greeting')
-        .send(stub.requestWithoutPrefetch)
-        .type('json')
-        .then((response) => {
-          expect(response.statusCode).toBe(412);
-          expect(response.body).toEqual({});
-          done();
-        });
+    describe('When a valid prefetch body is supplied', () => {
+      test('a request should yield a 200 status and CDS Service response in the body', (done) => {
+        request(app)
+          .post('/cds-services/patient-greeting')
+          .send(stub.requestWithPrefetch)
+          .type('json')
+          .then((response) => {
+            expect(response.statusCode).toBe(200);
+            expect(response.body).toEqual(stub.validResponse);
+            expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+            done();
+          });
+      });
     });
 
-    test('with prefetch data in a valid request should yield a 200 status and CDS Service response in the body', (done) => {
-      request(app)
-        .post('/cds-services/patient-greeting')
-        .send(stub.requestWithPrefetch)
-        .type('json')
-        .then((response) => {
-          expect(response.statusCode).toBe(200);
-          expect(response.body).toEqual(stub.validResponse);
-          expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
-          done();
+    describe('When an invalid prefetch body is supplied', () => {
+      test('a request without the fhirServer and patient field should yield a 412 status', (done) => {
+        request(app)
+          .post('/cds-services/patient-greeting')
+          .send(stub.requestWithoutPrefetch)
+          .type('json')
+          .then((response) => {
+            expect(response.statusCode).toBe(412);
+            done();
+          });
+      });
+
+      describe('and the passed in FHIR server is called', () => {
+        let requestStub;
+        let mock;
+
+        beforeEach(() => {
+          requestStub = stub.requestWithSecuredFhirServer;
+          mock = new MockAdapter(axios);
         });
+        afterEach(() => { mock.restore(); });
+
+        test('returns a card if the FHIR response was valid at an open endpoint', (done) => {
+          let headers;
+          requestStub = stub.requestWithOpenFhirServer;
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+            .reply((config) => {
+              headers = config.headers;
+              return [
+                200,
+                {
+                  name: [{
+                    given: [stub.givenName]
+                  }]
+                }
+              ];
+            });
+
+          request(app)
+            .post('/cds-services/patient-greeting')
+            .send(requestStub)
+            .type('json')
+            .then((response) => {
+              expect(response.statusCode).toBe(200);
+              expect(response.body).toEqual(stub.validResponse);
+              expect(headers['Authorization']).toBeUndefined();
+              done();
+            });
+        });
+
+        test('returns a card if the FHIR response was valid at a secured endpoint', (done) => {
+          let headers;
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+            .reply((config) => {
+              headers = config.headers;
+              return [
+                200,
+                {
+                  name: [{
+                    given: [stub.givenName]
+                  }]
+                }
+              ];
+            });
+
+          request(app)
+            .post('/cds-services/patient-greeting')
+            .send(requestStub)
+            .type('json')
+            .then((response) => {
+              expect(response.statusCode).toBe(200);
+              expect(response.body).toEqual(stub.validResponse);
+              expect(headers['Authorization']).toEqual(`Bearer ${requestStub.fhirAuthorization.access_token}`);
+              done();
+            });
+        });
+
+        test('returns a 412 if the FHIR service call failed', (done) => {
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+            .networkError();
+
+          request(app)
+            .post('/cds-services/patient-greeting')
+            .send(requestStub)
+            .type('json')
+            .then((response) => {
+              expect(response.statusCode).toBe(412);
+              done();
+            });
+        });
+
+        test('returns a 412 if the FHIR response is invalid', (done) => {
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+            .reply(200, {
+              name: [{
+                given: []
+              }]
+            });
+
+          request(app)
+            .post('/cds-services/patient-greeting')
+            .send(requestStub)
+            .type('json')
+            .then((response) => {
+              expect(response.statusCode).toBe(412);
+              done();
+            });
+        });
+      });
     });
   });
 });

--- a/tests/stubs/patient-greeting-stub.js
+++ b/tests/stubs/patient-greeting-stub.js
@@ -1,4 +1,9 @@
+function getGivenName() {
+  return 'Test';
+}
+
 module.exports = {
+  givenName: getGivenName(),
   requestWithPrefetch: {
     hook: 'patient-view',
     prefetch: {
@@ -7,7 +12,7 @@ module.exports = {
           name: [
             {
               given: [
-                'dummy',
+                `${getGivenName()}`,
               ],
             },
           ],
@@ -18,10 +23,23 @@ module.exports = {
   requestWithoutPrefetch: {
     hook: 'patient-view',
   },
+  requestWithSecuredFhirServer: {
+    hook: 'patient-view',
+    fhirServer: 'http://some-fhir-server/secured',
+    fhirAuthorization: {
+      access_token: 'foo-token'
+    },
+    patient: 'foo-id',
+  },
+  requestWithOpenFhirServer: {
+    hook: 'patient-view',
+    fhirServer: 'http://some-fhir-server/open',
+    patient: 'foo-id',
+  },
   validResponse: {
     cards: [
       {
-        summary: 'Now seeing: dummy',
+        summary: `Now seeing: ${getGivenName()}`,
         source: {
           label: 'Patient greeting service',
         },


### PR DESCRIPTION
Currently, the `patient-greeting` service relies on prefetch data from the EHR/entity calling it to be able to respond with a card, otherwise the service returns a `412` status code. While this is technically a valid response, the CDS service should also check the FHIR server (if passed in to the service call from the entity calling upon the service) to see if it can retrieve the necessary data it needs to build its card. 

We can first check to see if the data in a possible prefetch field contains all we need to build out the card response, and if the check fails, we can check to see if we can query a passed in FHIR server. We should account for if the FHIR server passed in is an open/secured endpoint by checking the `fhirAuthorization` field to see if an access token was passed in, which we can use to set in the `Authorization` header of the FHIR server call for the necessary resources the service needs. Any failures with the FHIR server call or any data needed for the service not being returned by the FHIR server will result in the eventual `412` status code. Otherwise, we can use the data the service fetches to build out the expected card for a response.

Fixes #3 