### PR TITLE
Fix prefetch template to read from context patientId property. Parse the context for patient ID in patient-greeting service accordingly

### DIFF
--- a/discovery/service-definitions.json
+++ b/discovery/service-definitions.json
@@ -5,7 +5,7 @@
     "description": "Display which patient the user is currently working with",
     "hook": "patient-view",
     "prefetch": {
-      "patient": "Patient/{{Patient.id}}"
+      "patient": "Patient/{{context.patientId}}"
     }
   },
   {

--- a/services/patient-greeting.js
+++ b/services/patient-greeting.js
@@ -48,7 +48,11 @@ function buildCard(patient) {
 // CDS Service endpoint
 router.post('/', (request, response) => {
   if (!isValidPrefetch(request)) {
-    const { fhirServer, fhirAuthorization, patient } = request.body;
+    const { fhirServer, fhirAuthorization } = request.body;
+    let patient;
+    if (request.body.context) {
+      patient = request.body.context.patientId;
+    }
     if (fhirServer && patient) {
       let accessToken;
       if (fhirAuthorization && fhirAuthorization.access_token) {

--- a/tests/patient-greeting.test.js
+++ b/tests/patient-greeting.test.js
@@ -69,7 +69,7 @@ describe('Patient Greeting Service Endpoint', () => {
         test('returns a card if the FHIR response was valid at an open endpoint', (done) => {
           let headers;
           requestStub = stub.requestWithOpenFhirServer;
-          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.context.patientId}`)
             .reply((config) => {
               headers = config.headers;
               return [
@@ -96,7 +96,7 @@ describe('Patient Greeting Service Endpoint', () => {
 
         test('returns a card if the FHIR response was valid at a secured endpoint', (done) => {
           let headers;
-          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.context.patientId}`)
             .reply((config) => {
               headers = config.headers;
               return [
@@ -122,7 +122,7 @@ describe('Patient Greeting Service Endpoint', () => {
         });
 
         test('returns a 412 if the FHIR service call failed', (done) => {
-          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.context.patientId}`)
             .networkError();
 
           request(app)
@@ -136,7 +136,7 @@ describe('Patient Greeting Service Endpoint', () => {
         });
 
         test('returns a 412 if the FHIR response is invalid', (done) => {
-          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.patient}`)
+          mock.onGet(`${requestStub.fhirServer}/Patient/${requestStub.context.patientId}`)
             .reply(200, {
               name: [{
                 given: []

--- a/tests/stubs/patient-greeting-stub.js
+++ b/tests/stubs/patient-greeting-stub.js
@@ -29,12 +29,16 @@ module.exports = {
     fhirAuthorization: {
       access_token: 'foo-token'
     },
-    patient: 'foo-id',
+    context: {
+      patientId: 'foo-id',
+    }
   },
   requestWithOpenFhirServer: {
     hook: 'patient-view',
     fhirServer: 'http://some-fhir-server/open',
-    patient: 'foo-id',
+    context: {
+      patientId: 'foo-id',
+    }
   },
   validResponse: {
     cards: [


### PR DESCRIPTION
Fixing both default services to parse the patient ID from the context `patientId` property to align with the current 1.0 spec. Additionally, changing the prefetch template on `patient-greeting` to use the `{{context.patientId}}` syntax to align with latest spec changes.