### PR TITLE
Parse medications property on context as a FHIR bundle. Cross check the patient subject in the Medication Order resource against DSTU2 and STU3 syntax. Add required description property to action on medication change suggestion

### DIFF
--- a/tests/cms-price-check.test.js
+++ b/tests/cms-price-check.test.js
@@ -71,6 +71,14 @@ describe('CMS Price Check Service Endpoint', () => {
         sendRequestAndVerifyEmptyResponse(stub.createContextWithPatientMismatch, done);
       });
 
+      test('when medications is not of type bundle', (done) => {
+        sendRequestAndVerifyEmptyResponse(stub.createContextWithoutBundleType, done);
+      });
+
+      test('when medications entries do not have the proper resource attribute', (done) => {
+        sendRequestAndVerifyEmptyResponse(stub.createContextWithoutProperEntry, done);
+      });
+
       test('when resource type does not match MedicationOrder or MedicationRequest', (done) => {
         sendRequestAndVerifyEmptyResponse(stub.createContextWithWrongResourceType, done);
       });

--- a/tests/stubs/cms-price-check-stub.js
+++ b/tests/stubs/cms-price-check-stub.js
@@ -1,80 +1,91 @@
 const rxnormSystem = 'http://www.nlm.nih.gov/research/umls/rxnorm';
 
 const createRequestContext = (resourceType, system, code) => {
+  let patientPropertyName = resourceType === 'MedicationOrder' ? 'patient' : 'subject';
   return {
-    resourceType: resourceType,
-    patient: { reference: 'Patient/patient-example' },
-    medicationCodeableConcept: {
-      coding: [
-        {
-          display: 'Some Arbitrary Medication',
-          system: system,
-          code: code
-        }
-      ]
-    }
+    resource: {
+      resourceType: resourceType,
+      [`${patientPropertyName}`]: { reference: 'Patient/patient-example' },
+      medicationCodeableConcept: {
+        coding: [
+          {
+            display: 'Some Arbitrary Medication',
+            system: system,
+            code: code,
+          },
+        ],
+      },
+    },
   };
 };
 
 const createContextWithMultipleCodings = () => {
   return {
-    resourceType: 'MedicationOrder',
-    patient: { reference: 'Patient/patient-example' },
-    medicationCodeableConcept: {
-      coding: [
-        {
-          display: 'Some Arbitrary Medication',
-          system: 'google.com',
-          code: '123'
-        },
-        {
-          display: 'Some Arbitrary Medication',
-          system: rxnormSystem,
-          code: '251374'
-        }
-      ]
-    }
-  }
+    resource: {
+      resourceType: 'MedicationOrder',
+      patient: { reference: 'Patient/patient-example' },
+      medicationCodeableConcept: {
+        coding: [
+          {
+            display: 'Some Arbitrary Medication',
+            system: 'google.com',
+            code: '123',
+          },
+          {
+            display: 'Some Arbitrary Medication',
+            system: rxnormSystem,
+            code: '251374',
+          },
+        ],
+      },
+    },
+  };
 };
 
 const createContextWithoutCoding = () => {
   return {
-    resourceType: 'MedicationOrder',
-    patient: { reference: 'Patient/patient-example' },
-    medicationCodeableConcept: {
-      foo: 'foo'
-    }
-  }
+    resource: {
+      resourceType: 'MedicationOrder',
+      patient: { reference: 'Patient/patient-example' },
+      medicationCodeableConcept: {
+        foo: 'foo',
+      },
+    },
+  };
 };
 
 const createContextWithoutMedCode = () => {
   return {
-    resourceType: 'MedicationOrder',
-    patient: { reference: 'Patient/patient-example' },
-    medicationCodeableConcept: {
-      coding: [
-        {
-          display: 'Some Arbitrary Medication',
-          system: rxnormSystem
-        }
-      ]
-    }
-  }
+    resource: {
+      resourceType: 'MedicationOrder',
+      patient: { reference: 'Patient/patient-example' },
+      medicationCodeableConcept: {
+        coding: [
+          {
+            display: 'Some Arbitrary Medication',
+            system: rxnormSystem
+          },
+        ],
+      },
+    },
+  };
 };
 
 const createContextWithoutPatientInMed = () => {
   return {
-    resourceType: 'MedicationOrder',
-    medicationCodeableConcept: {
-      coding: [
-        {
-          display: 'Some Arbitrary Medication',
-          system: rxnormSystem,
-          code: '251374'
-        }
-      ]
-    }
-  }
+    resource: {
+      resourceType: 'MedicationOrder',
+      medicationCodeableConcept: {
+        coding: [
+          {
+            display: 'Some Arbitrary Medication',
+            system: rxnormSystem,
+            code: '251374'
+          },
+        ],
+      },
+    },
+  };
 };
 
 const createResponseCard = (cost, newResource, savings) => {
@@ -95,6 +106,7 @@ const createResponseCard = (cost, newResource, savings) => {
           actions: [
             {
               type: 'create',
+              description: 'Create a resource with the newly suggested medication',
               resource: newResource
             }
           ]
@@ -146,7 +158,12 @@ module.exports = {
     return {
       context: {
         patientId: 'patient-example',
-        'medications': [ createRequestContext(resourceType || 'MedicationOrder', system || rxnormSystem, code) ]
+        medications: {
+          resourceType: 'Bundle',
+          entry: [
+            createRequestContext(resourceType || 'MedicationOrder', system || rxnormSystem, code),
+          ]
+        }
       }
     };
   },
@@ -154,58 +171,115 @@ module.exports = {
     return {
       context: {
         patientId: 'patient-example',
-        'medications': [
-          createRequestContext(resourceType || 'MedicationOrder', system || rxnormSystem, code),
-          createRequestContext('MedicationOrder', 'http://google.com', code)
-        ]
-      }
+        medications: {
+          resourceType: 'Bundle',
+          entry: [
+            createRequestContext(resourceType || 'MedicationOrder', system || rxnormSystem, code),
+            createRequestContext('MedicationOrder', 'http://google.com', code),
+          ],
+        },
+      },
     };
   },
   multipleCodingsInResource: {
     context: {
       patientId: 'patient-example',
-      'medications': [createContextWithMultipleCodings()]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createContextWithMultipleCodings(),
+        ],
+      },
+    },
   },
   createContextWithoutCoding: {
     context: {
       patientId: 'patient-example',
-      'medications': [ createContextWithoutCoding() ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createContextWithoutCoding(),
+        ],
+      },
+    },
   },
   createContextWithoutCode: {
     context: {
       patientId: 'patient-example',
-      'medications': [ createContextWithoutMedCode() ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createContextWithoutMedCode(),
+        ],
+      },
+    },
   },
   createContextWithoutPatient: {
     context: {
-      'medications': [ createRequestContext('MedicationOrder', rxnormSystem, '251374') ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createRequestContext('MedicationOrder', rxnormSystem, '251374'),
+        ],
+      },
+    },
   },
   createContextWithoutPatientInMed: {
     context: {
       patientId: 'patient-example',
-      'medications': [ createContextWithoutPatientInMed() ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createContextWithoutPatientInMed(),
+        ],
+      },
+    },
   },
   createContextWithPatientMismatch: {
     context: {
       patientId:'wrong-patient-example',
-      'medications': [ createRequestContext('MedicationOrder', rxnormSystem, '251374') ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createRequestContext('MedicationOrder', rxnormSystem, '251374'),
+        ],
+      },
+    },
   },
   createContextWithoutMedicationsInProgress: {
     context: {
-      patientId:'patient-example'
-    }
+      patientId:'patient-example',
+    },
   },
   createContextWithWrongResourceType: {
     context: {
       patientId:'patient-example',
-      'medications': [ createRequestContext('Patient', rxnormSystem, '251374') ]
-    }
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          createRequestContext('Patient', rxnormSystem, '251374'),
+        ],
+      },
+    },
+  },
+  createContextWithoutBundleType: {
+    context: {
+      patientId: 'patient-example',
+      medications: [ createRequestContext('Patient', rxnormSystem, '251374') ],
+    },
+  },
+  createContextWithoutProperEntry: {
+    context: {
+      patientId: 'patient-example',
+      medications: {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            foo: 'foo',
+          },
+        ],
+      },
+    },
   },
 
   /**


### PR DESCRIPTION
Currently, the `cms-price-check` service is parsing the `medications` property of `context` as an array of MedicationOrder/Request resources. We should revise the service to be parsing the property as a FHIR bundle of MedicationOrder/Request entry resources. Additionally, adding a mandatory `description` field to the action on the suggestion within this service. 