### PR TITLE
Fix prefetch parse for patient-greeting service to read the resource from the prefetch key directly

### DIFF
--- a/services/patient-greeting.js
+++ b/services/patient-greeting.js
@@ -9,10 +9,10 @@ function isDataAvailable(patient) {
 
 function isValidPrefetch(request) {
   const data = request.body;
-  if (!(data && data.prefetch && data.prefetch.patient && data.prefetch.patient.resource)) {
+  if (!(data && data.prefetch && data.prefetch.patient)) {
     return false;
   }
-  return isDataAvailable(data.prefetch.patient.resource);
+  return isDataAvailable(data.prefetch.patient);
 }
 
 function retrievePatientResource(fhirServer, patientId, accessToken) {
@@ -69,7 +69,7 @@ router.post('/', (request, response) => {
     response.sendStatus(412);
     return;
   }
-  const { resource } = request.body.prefetch.patient;
+  const resource = request.body.prefetch.patient;
   response.json(buildCard(resource));
 });
 

--- a/tests/stubs/patient-greeting-stub.js
+++ b/tests/stubs/patient-greeting-stub.js
@@ -8,15 +8,13 @@ module.exports = {
     hook: 'patient-view',
     prefetch: {
       patient: {
-        resource: {
-          name: [
-            {
-              given: [
-                `${getGivenName()}`,
-              ],
-            },
-          ],
-        },
+        name: [
+          {
+            given: [
+              `${getGivenName()}`,
+            ],
+          },
+        ],
       },
     },
   },


### PR DESCRIPTION
Fixing the way `patient-greeting` parses the prefetch body in the request to read directly from the prefetch key `patient` instead of through an extra step in a `resource` object.