### PR TITLE
feat: initial pama imaging service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
     - master
 node_js:
   - 'lts/*'
+  - 12
 cache:
   directories:
     - node_modules

--- a/discovery/cds-services.js
+++ b/discovery/cds-services.js
@@ -2,8 +2,9 @@ const express = require('express');
 
 const router = express.Router();
 const serviceDefinitions = require('./service-definitions');
-const patientGreetingService = require('../services/patient-greeting');
 const cmsPriceCheck = require('../services/cms-price-check');
+const pamaImagingService = require('../services/pama-imaging');
+const patientGreetingService = require('../services/patient-greeting');
 
 // Discovery Endpoint
 router.get('/', (request, response) => {
@@ -14,7 +15,8 @@ router.get('/', (request, response) => {
 });
 
 // Routes to patient-greeting CDS Service
-router.use('/patient-greeting', patientGreetingService);
 router.use('/cms-price-check', cmsPriceCheck);
+router.use('/pama-scenarios', pamaImagingService);
+router.use('/patient-greeting', patientGreetingService);
 
 module.exports = router;

--- a/discovery/cds-services.js
+++ b/discovery/cds-services.js
@@ -16,7 +16,7 @@ router.get('/', (request, response) => {
 
 // Routes to patient-greeting CDS Service
 router.use('/cms-price-check', cmsPriceCheck);
-router.use('/pama-scenarios', pamaImagingService);
+router.use('/pama-imaging', pamaImagingService);
 router.use('/patient-greeting', patientGreetingService);
 
 module.exports = router;

--- a/discovery/service-definitions.json
+++ b/discovery/service-definitions.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "cms-price-check",
+    "title": "CMS Pricing Service",
+    "description": "Determine if an authored prescription has a cheaper alternative to switch to and display pricing",
+    "hook": "order-select"
+  },
+  {
+    "id": "pama-imaging",
+    "title": "Pama Imaging Connectathon 2019 Scenarios",
+    "description": "Produce an appropriateness score according to scenario inputs.",
+    "hook": "pama-imaging"
+  },
+  {
     "id": "patient-greeting",
     "title": "Patient greeting",
     "description": "Display which patient the user is currently working with",
@@ -7,11 +19,5 @@
     "prefetch": {
       "patient": "Patient/{{context.patientId}}"
     }
-  },
-  {
-    "id": "cms-price-check",
-    "title": "CMS Pricing Service",
-    "description": "Determine if an authored prescription has a cheaper alternative to switch to and display pricing",
-    "hook": "order-select"
   }
 ]

--- a/discovery/service-definitions.json
+++ b/discovery/service-definitions.json
@@ -9,7 +9,7 @@
     "id": "pama-imaging",
     "title": "Pama Imaging Connectathon 2019 Scenarios",
     "description": "Produce an appropriateness score according to scenario inputs.",
-    "hook": "pama-imaging"
+    "hook": "order-select"
   },
   {
     "id": "patient-greeting",

--- a/middleware/error-handler.js
+++ b/middleware/error-handler.js
@@ -2,6 +2,7 @@
 
 module.exports = (err, request, response, next) => {
   const status = err.status || 500;
+  console.log("Returning 500", err);
   response.status(status);
   response.set('Content-Type', 'text/html');
   response.send(status !== 500 ? err.message : 'Internal Server Error');

--- a/middleware/error-handler.js
+++ b/middleware/error-handler.js
@@ -2,8 +2,7 @@
 
 module.exports = (err, request, response, next) => {
   const status = err.status || 500;
-  console.log("Returning 500", err);
   response.status(status);
   response.set('Content-Type', 'text/html');
-  response.send(status !== 500 ? err.message : 'Internal Server Error');
+  response.send(err.message + '\n' + err.stack);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -224,6 +225,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -1275,7 +1286,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -1458,7 +1468,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -1471,7 +1480,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
@@ -2102,8 +2110,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2159,910 +2166,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^0.4.1",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "~0.1.0"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "~0.1.0"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "~0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "~1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "^2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3239,7 +2346,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -3547,8 +2653,7 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
     "is-ci": {
       "version": "1.0.10",
@@ -3571,8 +2676,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3767,7 +2871,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -3793,8 +2896,7 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4575,7 +3677,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -4798,9 +3901,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -4960,6 +4063,556 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0",
             "upath": "^1.0.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "1.2.9",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+              "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aproba": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.6"
+                  }
+                },
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "chownr": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "debug": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "^2.1.1"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "detect-libc": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "fs-minipass": {
+                  "version": "1.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wide-align": "^1.1.0"
+                  }
+                },
+                "glob": {
+                  "version": "7.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.4",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "iconv-lite": {
+                  "version": "0.4.24",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safer-buffer": ">= 2.1.2 < 3"
+                  }
+                },
+                "ignore-walk": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minimatch": "^3.0.4"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "once": "^1.3.0",
+                    "wrappy": "1"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ini": {
+                  "version": "1.3.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "minipass": {
+                  "version": "2.3.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "^5.1.2",
+                    "yallist": "^3.0.0"
+                  }
+                },
+                "minizlib": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "needle": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "^4.1.0",
+                    "iconv-lite": "^0.4.4",
+                    "sax": "^1.2.4"
+                  }
+                },
+                "node-pre-gyp": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "detect-libc": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "needle": "^2.2.1",
+                    "nopt": "^4.0.1",
+                    "npm-packlist": "^1.1.6",
+                    "npmlog": "^4.0.2",
+                    "rc": "^1.2.7",
+                    "rimraf": "^2.6.1",
+                    "semver": "^5.3.0",
+                    "tar": "^4"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1",
+                    "osenv": "^0.1.4"
+                  }
+                },
+                "npm-bundled": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "npm-packlist": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ignore-walk": "^3.0.1",
+                    "npm-bundled": "^1.0.1"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "~1.1.2",
+                    "console-control-strings": "~1.1.0",
+                    "gauge": "~2.7.3",
+                    "set-blocking": "~2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "wrappy": "1"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "^1.0.0",
+                    "os-tmpdir": "^1.0.0"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "^0.6.0",
+                    "ini": "~1.3.0",
+                    "minimist": "^1.2.0",
+                    "strip-json-comments": "~2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "glob": "^7.1.3"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "safer-buffer": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "sax": {
+                  "version": "1.2.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "semver": {
+                  "version": "5.7.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "4.4.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "chownr": "^1.1.1",
+                    "fs-minipass": "^1.2.5",
+                    "minipass": "^2.3.4",
+                    "minizlib": "^1.1.1",
+                    "mkdirp": "^0.5.0",
+                    "safe-buffer": "^5.1.2",
+                    "yallist": "^3.0.2"
+                  }
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "wide-align": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "^1.0.2 || 2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "yallist": {
+                  "version": "3.0.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
           }
         },
         "debug": {
@@ -5360,8 +5013,7 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6440,7 +6092,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6461,12 +6114,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6481,17 +6136,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6608,7 +6266,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6620,6 +6279,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6634,6 +6294,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -6641,12 +6302,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -6665,6 +6328,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6745,7 +6409,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6757,6 +6422,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6842,7 +6508,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6878,6 +6545,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6897,6 +6565,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6940,12 +6609,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/cds-hooks/sandbox-cds-services#readme",
   "dependencies": {
+    "array.prototype.flat": "^1.2.1",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "express": "^4.16.3",

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -1,0 +1,5 @@
+const express = require('express');
+
+const router = express.Router();
+
+module.exports = router;

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable quote-props */
 const express = require('express');
+const flat = require('array.prototype.flat');
 const uuid = require('uuid');
 
 const router = express.Router();
@@ -8,6 +9,7 @@ const router = express.Router();
 const SNOMED = 'http://snomed.info/sct';
 const CPT = 'http://www.ama-assn.org/go/cpt';
 
+flat.shim();
 
 class Reasons {
   static covers(subset, set) {

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -2,4 +2,52 @@ const express = require('express');
 
 const router = express.Router();
 
+
+function extractInput(request) {
+  // TODO: return a dictionary with only the important logical bits present.
+  return request;
+}
+
+function getResponse(pamaRating) {
+  return {
+    extension: {
+      systemActions: [{
+        resource: {
+          extension: [
+            {
+              url: 'http://fhir.org/argonaut/Extension/pama-rating',
+              valueCodeableConcept: {
+                coding: [{
+                  system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
+                  code: pamaRating,
+                }],
+              },
+            },
+            {
+              url: 'http://fhir.org/argonaut/Extension/pama-rating-qcdsm-consulted',
+              valueString: 'example-gcode',
+            },
+            {
+              url: 'http://fhir.org/argonaut/Extension/pama-rating-consult-id',
+              valueUri: 'urn:uuid:55f3b7fc-9955-420e-a460-ff284b2956e6',
+            },
+          ],
+        },
+        type: 'update',
+      }],
+    },
+  }
+}
+
+function determinePamaRating(input) {
+  // TODO: apply logic here.
+  return 'appropriate';
+}
+
+router.post('/', (request, response) => {
+  const input = extractInput(request.body);
+  const coding = determinePamaRating(input);
+  response.json(getResponse(coding));
+});
+
 module.exports = router;

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -33,9 +33,10 @@ class Reasons {
 }
 
 const cptReasons = {
-  '72133': new Reasons([], [['279039007']]),
-  '70450': new Reasons([['25064002', '423341008 ']], []),
+  '70450': new Reasons([['25064002', '423341008']], []),
   '70544': new Reasons([], []),
+  '72133': new Reasons([], [['279039007']]),
+  '75561': new Reasons([['13213009']], []),
 };
 
 function findCodes(codes, systemName) {

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -2,52 +2,55 @@ const express = require('express');
 
 const router = express.Router();
 
-
-function extractInput(request) {
-  // TODO: return a dictionary with only the important logical bits present.
-  return request;
+/**
+ * Finds a resource from a bundle matching a selection.
+ *
+ * @param {*} entries a list of resources.
+ * @param {*} selection a selected resource string matching the form 'Type/Id'.
+ */
+function findResource(entries, selection) {
+  const [resourceType, resourceId] = selection.split('/');
+  return entries
+    .map(e => e.resource)
+    .filter(r => r.resourceType === resourceType && r.id === resourceId);
 }
 
-function getResponse(pamaRating) {
-  return {
-    extension: {
-      systemActions: [{
-        resource: {
-          extension: [
-            {
-              url: 'http://fhir.org/argonaut/Extension/pama-rating',
-              valueCodeableConcept: {
-                coding: [{
-                  system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
-                  code: pamaRating,
-                }],
-              },
-            },
-            {
-              url: 'http://fhir.org/argonaut/Extension/pama-rating-qcdsm-consulted',
-              valueString: 'example-gcode',
-            },
-            {
-              url: 'http://fhir.org/argonaut/Extension/pama-rating-consult-id',
-              valueUri: 'urn:uuid:55f3b7fc-9955-420e-a460-ff284b2956e6',
-            },
-          ],
-        },
-        type: 'update',
-      }],
+function getSystemActions(entries, selections) {
+  const r = findResource(entries, selections[0]);
+  r.extension = [
+    {
+      url: 'http://fhir.org/argonaut/Extension/pama-rating',
+      valueCodeableConcept: {
+        coding: [{
+          system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
+          code: 'appropriate',
+        }],
+      },
     },
-  }
-}
-
-function determinePamaRating(input) {
-  // TODO: apply logic here.
-  return 'appropriate';
+    {
+      url: 'http://fhir.org/argonaut/Extension/pama-rating-qcdsm-consulted',
+      valueString: 'example-gcode',
+    },
+    {
+      url: 'http://fhir.org/argonaut/Extension/pama-rating-consult-id',
+      valueUri: 'urn:uuid:55f3b7fc-9955-420e-a460-ff284b2956e6',
+    },
+  ];
+  return [{
+    resource: r,
+    type: 'update',
+  }];
 }
 
 router.post('/', (request, response) => {
-  const input = extractInput(request.body);
-  const coding = determinePamaRating(input);
-  response.json(getResponse(coding));
+  const entries = request.body.context.draftOrders.entry;
+  const { selections } = request.body.context;
+  response.json({
+    cards: [],
+    extension: {
+      systemActions: getSystemActions(entries, selections),
+    },
+  });
 });
 
 module.exports = router;

--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -11,8 +11,14 @@ const CPT = 'http://www.ama-assn.org/go/cpt';
 
 class Reasons {
   static covers(subset, set) {
-    if (subset.size > set.size) return false;
-    for (const member of subset) if (!set.has(member)) return false;
+    if (subset.size > set.size) {
+      return false;
+    }
+    for (const member of subset) {
+      if (!set.has(member)) {
+        return false;
+      }
+    }
     return true;
   }
 
@@ -33,6 +39,7 @@ class Reasons {
 }
 
 const cptReasons = {
+  '1234': new Reasons([['1']], [['2', '3']]), // testing only
   '70450': new Reasons([['25064002', '423341008']], []),
   '70544': new Reasons([], []),
   '72133': new Reasons([], [['279039007']]),
@@ -49,7 +56,6 @@ function findCodes(codes, systemName) {
 
 function getRatings(resource) {
   const cpt = findCodes([resource.code], CPT);
-  if (!cpt.length) return [];
   if (!(cpt[0] in cptReasons)) return [];
   const reasons = new Set(findCodes(resource.reasonCode, SNOMED));
   const rating = cptReasons[cpt[0]].getRating(reasons);

--- a/tests/middleware/error-handler.test.js
+++ b/tests/middleware/error-handler.test.js
@@ -28,13 +28,12 @@ describe('Error Handler', () => {
     errorHandler(err, null, res, null);
 
     expect(res.code).toBe(404);
-    expect(res.data).toBe('Not Found');
   });
 
   test('returns a 500 if no error status has been specified', () => {
     errorHandler(new Error(), null, res, null);
 
     expect(res.code).toBe(500);
-    expect(res.data).toBe('Internal Server Error');
+    expect(res.data.length > 50);
   });
 });

--- a/tests/pama-imaging.test.js
+++ b/tests/pama-imaging.test.js
@@ -1,9 +1,46 @@
-/* eslint-env mocha */
+/* eslint-env jest */
 
-// const request = require('supertest');
+const app = require('../index.js');
+const stub = require('./stubs/pama-imaging-stub');
+
+// Basing content tests on
+// https://github.com/argonautproject/cds-hooks-for-pama/blob/master/connectathon-scenarios-2019-09/README.md
+
+const request = require('supertest');
 
 describe('PAMA Imaging Service Endpoint', () => {
-  test('it returns true', (done) => {
+  test('It returns an "not-appropriate" rating, given "spine CT for low back pain"', async (done) => {
+    const input = stub.scenario1request;
+    const response = await request(app)
+      .post('/cds-services/pama-imaging')
+      .send(input)
+      .type('json');
+
+    expect(response.status).toEqual(200);
+    const { systemActions } = response.body.extension;
+
+    expect(systemActions).toHaveLength(1);
+    expect(systemActions[0].type).toEqual('update');
+    const ratings = systemActions[0]
+      .resource
+      .extension
+      .filter(e => e.url === 'http://fhir.org/argonaut/Extension/pama-rating')
+      .map(e => e.valueCodeableConcept.coding[0]);
+
+    expect(ratings).toHaveLength(1);
+    expect(ratings[0]).toEqual({
+      system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
+      code: 'not-appropriate',
+    });
+
+    done();
+  });
+
+  test('It returns an "appropriate" rating, given "Abdominal MRI for pancreatitis with kidney disease"', (done) => {
+    done();
+  });
+
+  test('It returns no rating, given "CT angiogram of chest for Dyspnea"', (done) => {
     done();
   });
 });

--- a/tests/pama-imaging.test.js
+++ b/tests/pama-imaging.test.js
@@ -17,6 +17,7 @@ describe('PAMA Imaging Service Endpoint', () => {
       .type('json');
 
     expect(response.status).toEqual(200);
+    console.log(response.body);
     const { systemActions } = response.body.extension;
 
     expect(systemActions).toHaveLength(1);

--- a/tests/pama-imaging.test.js
+++ b/tests/pama-imaging.test.js
@@ -9,15 +9,13 @@ const stub = require('./stubs/pama-imaging-stub');
 const request = require('supertest');
 
 describe('PAMA Imaging Service Endpoint', () => {
-  test('It returns an "not-appropriate" rating, given "spine CT for low back pain"', async (done) => {
-    const input = stub.scenario1request;
+  async function confirm(rating, input, done) {
     const response = await request(app)
       .post('/cds-services/pama-imaging')
       .send(input)
       .type('json');
 
     expect(response.status).toEqual(200);
-    console.log(response.body);
     const { systemActions } = response.body.extension;
 
     expect(systemActions).toHaveLength(1);
@@ -31,13 +29,25 @@ describe('PAMA Imaging Service Endpoint', () => {
     expect(ratings).toHaveLength(1);
     expect(ratings[0]).toEqual({
       system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
-      code: 'not-appropriate',
+      code: rating,
     });
 
     done();
+  }
+
+  test('It returns "not-appropriate", given "spine CT for low back pain"', (done) => {
+    confirm('not-appropriate', stub.s1r1, done);
   });
 
-  test('It returns an "appropriate" rating, given "Abdominal MRI for pancreatitis with kidney disease"', (done) => {
+  test('It returns "appropriate", given "CT head for multiple reasons"', (done) => {
+    confirm('appropriate', stub.s1r2, done);
+  });
+
+  test('It returns "no-guidelines-apply", given "MRI for a toothache"', (done) => {
+    confirm('no-guidelines-apply', stub.s1r3, done);
+  });
+
+  test('It returns "appropriate", given "Abdominal MRI for pancreatitis with kidney disease"', (done) => {
     done();
   });
 

--- a/tests/pama-imaging.test.js
+++ b/tests/pama-imaging.test.js
@@ -18,22 +18,38 @@ describe('PAMA Imaging Service Endpoint', () => {
     expect(response.status).toEqual(200);
     const { systemActions } = response.body.extension;
 
-    expect(systemActions).toHaveLength(1);
-    expect(systemActions[0].type).toEqual('update');
-    const ratings = systemActions[0]
-      .resource
-      .extension
-      .filter(e => e.url === 'http://fhir.org/argonaut/Extension/pama-rating')
-      .map(e => e.valueCodeableConcept.coding[0]);
+    if (systemActions.length > 0) {
+      expect(systemActions).toHaveLength(1);
+      expect(systemActions[0].type).toEqual('update');
+      const ratings = systemActions[0]
+        .resource
+        .extension
+        .filter(e => e.url === 'http://fhir.org/argonaut/Extension/pama-rating')
+        .map(e => e.valueCodeableConcept.coding[0]);
 
-    expect(ratings).toHaveLength(1);
-    expect(ratings[0]).toEqual({
-      system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
-      code: rating,
-    });
+      if (ratings.length > 0) {
+        expect(ratings).toHaveLength(1);
+        expect(ratings[0]).toEqual({
+          system: 'http://fhir.org/argonaut/CodeSystem/pama-rating',
+          code: rating,
+        });
+      }
+    }
 
     done();
   }
+
+  test('It returns "no-guidelines-apply" when no reason is given.', (done) => {
+    confirm('no-guidelines-apply', stub.dummy1, done);
+  });
+
+  test('It returns "no-guidelines-apply when no reason is given.', (done) => {
+    confirm('no-guidelines-apply', stub.dummy2, done);
+  });
+
+  test('It returns "no-guidelines-apply when no cpt is given.', (done) => {
+    confirm('no-guidelines-apply', stub.dummy3, done);
+  });
 
   test('It returns "not-appropriate", given "spine CT for low back pain"', (done) => {
     confirm('not-appropriate', stub.s1r1, done);

--- a/tests/pama-imaging.test.js
+++ b/tests/pama-imaging.test.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+
+// const request = require('supertest');
+
+describe('PAMA Imaging Service Endpoint', () => {
+  test('it returns true', (done) => {
+    done();
+  });
+});

--- a/tests/stubs/pama-imaging-stub.js
+++ b/tests/stubs/pama-imaging-stub.js
@@ -1,0 +1,43 @@
+module.exports = {
+  scenario1request: {
+    hook: 'order-select',
+    hookInstance: 'd1577c69-dfbe-44ad-ba6d-3e05e953b2ea',
+    fhirServer: 'http://hooks.smarthealthit.org',
+    context: {
+      userId: 'Practitioner/123',
+      patientId: 'MRI-59879846',
+      encounterId: '89284',
+      selections: [
+        'ServiceRequest/example-MRI-59879846',
+      ],
+      draftOrders: {
+        resourceType: 'Bundle',
+        entry: [{
+          resource: {
+            resourceType: 'ServiceRequest',
+            id: 'example-MRI-59879846',
+            status: 'draft',
+            intent: 'plan',
+            code: {
+              coding: [{
+                system: 'http://www.ama-assn.org/go/cpt',
+                code: '72133',
+              }],
+              text: 'Lumbar spine CT',
+            },
+            subject: {
+              reference: 'Patient/MRI-59879846',
+            },
+            reasonCode: [{
+              coding: [{
+                system: 'http://snomed.info/sct',
+                code: '279039007',
+                display: 'Low back pain',
+              }],
+            }],
+          },
+        }],
+      },
+    },
+  },
+};

--- a/tests/stubs/pama-imaging-stub.js
+++ b/tests/stubs/pama-imaging-stub.js
@@ -1,43 +1,102 @@
-module.exports = {
-  scenario1request: {
-    hook: 'order-select',
-    hookInstance: 'd1577c69-dfbe-44ad-ba6d-3e05e953b2ea',
-    fhirServer: 'http://hooks.smarthealthit.org',
+const uuid = require('uuid');
+
+function getReasons(reasons) {
+  return reasons.map(r => (
+    {
+      coding: r.reasons.map(x => (
+        {
+          system: 'http://snomed.info/sct',
+          code: x.code,
+          display: x.display,
+        }
+      )),
+    }
+  ));
+}
+
+function getResources(
+  bundle, patientId,
+  intent = 'plan',
+  resourceType = 'ServiceRequest',
+  status = 'draft',
+) {
+  return bundle.map(x => (
+    {
+      resource: {
+        resourceType,
+        id: `example-${patientId}`,
+        status,
+        intent,
+        code: {
+          coding: [{
+            system: 'http://www.ama-assn.org/go/cpt',
+            code: x.code,
+          }],
+          text: x.text,
+        },
+        subject: {
+          reference: `Patient/${patientId}`,
+        },
+        reasonCode: getReasons(x.snomed),
+      },
+    }
+  ));
+}
+
+function getRequest(
+  bundle,
+  encounterId = '89284',
+  fhirServer = 'http://hooks.smarthealthit.org',
+  hook = 'order-select',
+  patientId = 'MRI-59879846',
+  userId = 'Practitioner/123',
+) {
+  return {
+    hook,
+    hookInstance: `${uuid.v4()}`,
+    fhirServer,
     context: {
-      userId: 'Practitioner/123',
-      patientId: 'MRI-59879846',
-      encounterId: '89284',
-      selections: [
-        'ServiceRequest/example-MRI-59879846',
-      ],
+      userId,
+      patientId,
+      encounterId,
+      selections: [`ServiceRequest/example-${patientId}`],
       draftOrders: {
         resourceType: 'Bundle',
-        entry: [{
-          resource: {
-            resourceType: 'ServiceRequest',
-            id: 'example-MRI-59879846',
-            status: 'draft',
-            intent: 'plan',
-            code: {
-              coding: [{
-                system: 'http://www.ama-assn.org/go/cpt',
-                code: '72133',
-              }],
-              text: 'Lumbar spine CT',
-            },
-            subject: {
-              reference: 'Patient/MRI-59879846',
-            },
-            reasonCode: [{
-              coding: [{
-                system: 'http://snomed.info/sct',
-                code: '279039007',
-                display: 'Low back pain',
-              }],
-            }],
-          },
-        }],
+        entry: getResources(bundle, patientId),
       },
     },
-  },
+  };
+}
+
+module.exports = {
+  s1r1: getRequest([{
+    code: '72133',
+    text: 'Lumbar spine CT',
+    snomed: [{
+      reasons: [
+        { code: '279039007', display: 'Low back pain' },
+      ],
+    }],
+  }]),
+
+  s1r2: getRequest([{
+    code: '70450',
+    text: 'CT head without contrast',
+    snomed: [{
+      reasons: [
+        { code: '25064002', display: 'Headache' },
+        { code: '423341008', display: 'Optic disc edema' },
+      ],
+    }],
+  }]),
+
+  s1r3: getRequest([{
+    code: '70544',
+    text: 'Magnetic resonance angiography, head',
+    snomed: [{
+      reasons: [
+        { code: '27355003', display: 'Toothache (finding)' },
+      ],
+    }],
+  }]),
 };

--- a/tests/stubs/pama-imaging-stub.js
+++ b/tests/stubs/pama-imaging-stub.js
@@ -1,6 +1,6 @@
 const uuid = require('uuid');
 
-function getReasons(reasons) {
+function makeReasons(reasons) {
   return reasons.map(r => (
     {
       coding: r.reasons.map(x => (
@@ -14,7 +14,7 @@ function getReasons(reasons) {
   ));
 }
 
-function getResources(
+function makeResources(
   bundle, patientId,
   intent = 'plan',
   resourceType = 'ServiceRequest',
@@ -37,13 +37,13 @@ function getResources(
         subject: {
           reference: `Patient/${patientId}`,
         },
-        reasonCode: getReasons(x.snomed),
+        reasonCode: makeReasons(x.snomed),
       },
     }
   ));
 }
 
-function getRequest(
+function makeRequest(
   bundle,
   encounterId = '89284',
   fhirServer = 'http://hooks.smarthealthit.org',
@@ -62,14 +62,14 @@ function getRequest(
       selections: [`ServiceRequest/example-${patientId}`],
       draftOrders: {
         resourceType: 'Bundle',
-        entry: getResources(bundle, patientId),
+        entry: makeResources(bundle, patientId),
       },
     },
   };
 }
 
 module.exports = {
-  s1r1: getRequest([{
+  s1r1: makeRequest([{
     code: '72133',
     text: 'Lumbar spine CT',
     snomed: [{
@@ -79,7 +79,7 @@ module.exports = {
     }],
   }]),
 
-  s1r2: getRequest([{
+  s1r2: makeRequest([{
     code: '70450',
     text: 'CT head without contrast',
     snomed: [{
@@ -90,7 +90,7 @@ module.exports = {
     }],
   }]),
 
-  s1r3: getRequest([{
+  s1r3: makeRequest([{
     code: '70544',
     text: 'Magnetic resonance angiography, head',
     snomed: [{
@@ -98,5 +98,29 @@ module.exports = {
         { code: '27355003', display: 'Toothache (finding)' },
       ],
     }],
+  }]),
+
+  dummy1: makeRequest([{
+    code: '1234',
+    text: 'Procedure with no reason given',
+    snomed: [],
+  }]),
+
+  dummy2: makeRequest([{
+    code: '1234',
+    text: 'Procedure with more reasons than needed',
+    snomed: [{
+      reasons: [
+        { code: '4', display: 'Dummy reason 2' },
+        { code: '5', display: 'Dummy reason 3' },
+        { code: '6', display: 'Dummy reason 4' },
+      ],
+    }],
+  }]),
+
+  dummy3: makeRequest([{
+    code: '',
+    text: '',
+    snomed: [],
   }]),
 };


### PR DESCRIPTION
Adds a new service endpoint for testing the PAMA Imaging scenarios for the 2019 Connectathon in Atlanta.

TODO(barabo):
- [x] Advertise a new service in the discovery endpoint
- [x] Create a skeletal service which does nothing
- [x] Create a skeletal unit test for the service
- [x] Scenario 1
  - [x] Cover a `not-appropriate` case
  - [x] Cover an `appropriate` case
  - [x] Cover a `no-guidelines-apply` case
