### PR TITLE
Scenario 2 of the 2019 Connectathon [WIP]

### DIFF
--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -109,11 +109,15 @@ function getSystemActions(entries, selections) {
   ));
 }
 
+function getCards() {
+  return [];
+}
+
 router.post('/', (request, response) => {
   const entries = request.body.context.draftOrders.entry;
   const { selections } = request.body.context;
   response.json({
-    cards: [],
+    cards: getCards(),
     extension: {
       systemActions: getSystemActions(entries, selections),
     },


### PR DESCRIPTION
[Scenario 2](https://github.com/argonautproject/cds-hooks-for-pama/blob/master/connectathon-scenarios-2019-09/README.md#scenario-2-suggestions-for-alternative-orders-presented-in-workflow):
  - [ ] Implement card-building logic in `pama-imaging.js`
  - [ ] Transform existing `Reasons` data into reverse-mapped recommendation data (from `yes` reasons to CPT)
  - [ ] Full unit test coverage of new code