### PR TITLE
Add displays to PAMA suggestion

### DIFF
--- a/services/pama-imaging.js
+++ b/services/pama-imaging.js
@@ -87,12 +87,19 @@ const CARD_TEMPLATES = {
           type: 'update',
           description: 'Update order to MRI',
           resource: { // Placeholder resource.
-            code: { coding: [{ code: CPT.CARDIAC_MRI, system: CPT._FHIR_CODING_SYSTEM }] },
+            code: {
+              coding: [{
+                code: CPT.CARDIAC_MRI,
+                system: CPT._FHIR_CODING_SYSTEM,
+                display: 'Cardiac MRI',
+              }],
+            },
             reasonCode: [{
               coding: [
                 {
                   code: SNOMED.CONGENITAL_HEART_DISEASE,
                   system: SNOMED._FHIR_CODING_SYSTEM,
+                  display: 'Congenital heart disease',
                 },
               ],
             }],


### PR DESCRIPTION
The public sandbox isn't yet smart enough to do a display lookup based on a supplied code.  Rather, it displays whatever coding.display value is provided.  That means that currently in the PAMA tab, when a suggestion comes back in a card for a study/reason w/o displays, the sandbox doesn't show the result of accepting the suggestion.

In the future, the sandbox should be more resilient to look up the value, but this minor change bumps current state to a demoable level.