### PR TITLE
Add feedback endpoint to CMS Price Check service

### DIFF
--- a/services/cms-price-check.js
+++ b/services/cms-price-check.js
@@ -174,10 +174,10 @@ router.post('/', (request, response) => {
   response.json(cards);
 });
 
-// Analytics endpoint
-// Because this is a sample service, this service won't include logic to store suggestion UUIDs
-// externally to some store to validate the UUID parameter at the analytics endpoint
-router.post('/analytics/:uuid', (request, response) => {
+// Feedback endpoint
+// Because this is a sample service, this service won't include logic to store card or suggestion
+// UUIDs externally to some store to validate the UUID parameter at the feedback endpoint
+router.post('/feedback', (request, response) => {
   response.sendStatus(200);
 });
 

--- a/tests/cms-price-check.test.js
+++ b/tests/cms-price-check.test.js
@@ -108,10 +108,10 @@ describe('CMS Price Check Service Endpoint', () => {
       });
     });
 
-    describe('Analytics Endpoint', () => {
-      test('returns a 200 for any UUID param', (done) => {
+    describe('Feedback Endpoint', () => {
+      test('returns a 200 for any request', (done) => {
         request(app)
-          .post('/cds-services/cms-price-check/analytics/123')
+          .post('/cds-services/cms-price-check/feedback')
           .send({})
           .type('json')
           .then((response) => {


### PR DESCRIPTION
Fixes https://github.com/cds-hooks/sandbox-cds-services/issues/26

Converts existing analytics endpoint to a simple feedback endpoint that returns a 200