### PR TITLE
Return overrideReasons with Price Check service

### DIFF
--- a/services/cms-price-check.js
+++ b/services/cms-price-check.js
@@ -84,6 +84,19 @@ function constructCard(summary, suggestionResource) {
         },
       ],
     }];
+
+    card.overrideReasons = [
+      {
+        code: 'patient-requested-brand',
+        system: 'http://terminology.cds-hooks.org/CodeSystem/OverrideReasons',
+        display: 'Patient Requested Brand Product',
+      },
+      {
+        code: 'generic-drug-unavailable',
+        system: 'http://terminology.cds-hooks.org/CodeSystem/OverrideReasons',
+        display: 'Generic Drug Out of Stock or Unavailable',
+      },
+    ];
   }
   return card;
 }

--- a/tests/cms-price-check.test.js
+++ b/tests/cms-price-check.test.js
@@ -168,6 +168,12 @@ describe('CMS Price Check Service Endpoint', () => {
                   });
                 }
               }
+
+              expect(resCard.overrideReasons).not.toHaveLength(0);
+              const overrideReasonKeys = ['code', 'display', 'system'];
+              resCard.overrideReasons.forEach((reason) => {
+                expect(Object.keys(reason).sort()).toEqual(overrideReasonKeys);
+              });
             }
             expect(resCard.summary).toEqual('Cost: $5.47. Save $0.73 with a generic medication.');
             verifyStatusAndHeaders(response);


### PR DESCRIPTION
Fixes #25 by adding override Reasons to the price check service.

I'm completely open to suggestions for other override reason terminologies/values, but this should get us started.